### PR TITLE
Move schema changelog to bottom of docs page

### DIFF
--- a/tools/docgen/index.qmd.jinja2
+++ b/tools/docgen/index.qmd.jinja2
@@ -4,8 +4,6 @@ subtitle: Schema documentation generated from linkml sources.
 date-modified: {{ gen.timestamp }}
 ---
 
-{{ schema.description }}
-
 URI: {{ schema.id }}
 Name: {{ schema.name }}
 
@@ -126,3 +124,11 @@ No enumerations are defined.
 {% else %}
 No subsets are defined.
 {% endif %}
+
+## Revision history
+
+::: {.callout-note collapse="true"}
+## Schema changelog
+
+{{ schema.description }}
+:::


### PR DESCRIPTION
The schema \`description\` field is actually a revision-history changelog (\"SMR 2022-10-07. Schema for iSamples sample registry integration. Updated from 0.2 by ...\"), not a conceptual introduction. Rendering it at the top of https://isamples.org/metadata/ makes the page feel dense and dated before the reader has any orientation.

Moves it into a collapsed \"Revision history\" callout at the bottom of the page. The hand-written \"How this schema is organized\" section (from #205) now leads the page.

Follow-up to #204 / #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)